### PR TITLE
fix(android): Rename loginunidentifieduser to loginUnidentifiedUser

### DIFF
--- a/android/src/main/java/com/sencrop/capacitor/intercom/IntercomPlugin.java
+++ b/android/src/main/java/com/sencrop/capacitor/intercom/IntercomPlugin.java
@@ -114,7 +114,7 @@ public class IntercomPlugin extends Plugin {
     }
 
     @PluginMethod
-    public void loginunidentifieduser(PluginCall call) {
+    public void loginUnidentifiedUser(PluginCall call) {
         Intercom
             .client()
             .loginUnidentifiedUser(


### PR DESCRIPTION
* Fixes bad naming of android function `loginUnidentifiedUser` causes `Msg: ERROR Error: "Intercom.loginUnidentifiedUser()" is not implemented on android`