### PR TITLE
Feat: upgrade iOS Capacitor SDK version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -55,6 +55,6 @@ dependencies {
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
-    implementation 'io.intercom.android:intercom-sdk-base:15.5.0'
+    implementation 'io.intercom.android:intercom-sdk-base:15.2.0'
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -55,6 +55,6 @@ dependencies {
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
-    implementation 'io.intercom.android:intercom-sdk-base:15.2.0'
+    implementation 'io.intercom.android:intercom-sdk-base:15.5.0'
 }
 

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -5,7 +5,7 @@ def capacitor_pods
   use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
-  pod 'Intercom', '~> 16.0.2'
+  pod 'Intercom', '~> 16.3.1'
 end
 
 target 'Plugin' do

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2,12 +2,12 @@ PODS:
   - Capacitor (5.4.2):
     - CapacitorCordova
   - CapacitorCordova (5.4.2)
-  - Intercom (16.0.2)
+  - Intercom (16.3.1)
 
 DEPENDENCIES:
   - "Capacitor (from `../node_modules/@capacitor/ios`)"
   - "CapacitorCordova (from `../node_modules/@capacitor/ios`)"
-  - Intercom (~> 16.0.2)
+  - Intercom (~> 16.3.1)
 
 SPEC REPOS:
   trunk:
@@ -22,8 +22,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Capacitor: 8a9db42d105f55843cd8ed2a3cb54e2b78e7f102
   CapacitorCordova: cfcc06b698481da655415985eeb2b8da363f8451
-  Intercom: 605585b4c8d59f47269dde4f70c9702fbe0e8612
+  Intercom: 7e36545cc576e16e2dfe02578c0163a219b74bae
 
-PODFILE CHECKSUM: 2427ae9e56f664ec6464ddca61d4f6e3a723e401
+PODFILE CHECKSUM: 0467542ce096e2e3dc2695d9753038e985012cc5
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.12.1


### PR DESCRIPTION
This pull request update Capacitor SDK version:
- iOS: 16.0.2 to 16.3.1

Many problems have been encountered on iOS, with numerous crashes. It would appear that the new versions of the SDK correct these problems.