### PR TITLE
feat(intercom-sdk): Update Android to v15.10.3 & iOS to v18.1.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,6 +3,7 @@ ext {
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.6.1'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.5'
     androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.5.1'
+    intercomSdkVersion = project.hasProperty('intercomSdkVersion') ? rootProject.ext.intercomSdkVersion : '15.10.3'
 }
 
 buildscript {
@@ -55,6 +56,6 @@ dependencies {
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
-    implementation 'io.intercom.android:intercom-sdk-base:15.2.0'
+    implementation "io.intercom.android:intercom-sdk-base:$intercomSdkVersion"
 }
 

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,11 +1,11 @@
-platform :ios, '13.0'
+platform :ios, '15.0'
 
 def capacitor_pods
   # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
   use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
-  pod 'Intercom', '~> 16.3.1'
+  pod 'Intercom', '~> 18.1.0'
 end
 
 target 'Plugin' do

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
-  - Capacitor (5.4.2):
+  - Capacitor (6.1.0):
     - CapacitorCordova
-  - CapacitorCordova (5.4.2)
-  - Intercom (16.3.1)
+  - CapacitorCordova (6.1.0)
+  - Intercom (18.1.0)
 
 DEPENDENCIES:
   - "Capacitor (from `../node_modules/@capacitor/ios`)"
   - "CapacitorCordova (from `../node_modules/@capacitor/ios`)"
-  - Intercom (~> 16.3.1)
+  - Intercom (~> 18.1.0)
 
 SPEC REPOS:
   trunk:
@@ -20,10 +20,10 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@capacitor/ios"
 
 SPEC CHECKSUMS:
-  Capacitor: 8a9db42d105f55843cd8ed2a3cb54e2b78e7f102
-  CapacitorCordova: cfcc06b698481da655415985eeb2b8da363f8451
-  Intercom: 7e36545cc576e16e2dfe02578c0163a219b74bae
+  Capacitor: 187bd7847b6f71467015a20200a1a071be3e5f14
+  CapacitorCordova: be703980ca797f847c3356f78fa175d21c8330c2
+  Intercom: b3a7282d46c7a670d805b70430cb929d9473ddb1
 
-PODFILE CHECKSUM: 0467542ce096e2e3dc2695d9753038e985012cc5
+PODFILE CHECKSUM: a5c143abb2064c506fde5c5a8ec0ae23e76f2723
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.15.2


### PR DESCRIPTION
fix: https://github.com/sencrop/capacitor-intercom/issues/32

Update Android to v15.10.3 & iOS to v18.1.0
iOS min version move from iOS 13 to iOS 15.