### PR TITLE
fix(ios): fix build issue

### DIFF
--- a/ios/Plugin/IntercomPlugin.swift
+++ b/ios/Plugin/IntercomPlugin.swift
@@ -32,12 +32,12 @@ public class IntercomPlugin: CAPPlugin {
             return
         }
         
-        do {
-            Intercom.setDeviceToken(deviceToken) { error in
+        Intercom.setDeviceToken(deviceToken, completion: { result in
+            if case .failure(let error) = result {
                 print("[Intercom SDK] Error while setting device token")
-                print(error ?? "Unknwown error")
+                print(error)
             }
-        }
+        })
     }
     
     @objc func updateUser(_ call: CAPPluginCall) {


### PR DESCRIPTION
Fix the following error in the ios build:

```
/Users/[REDACTED]/git/node_modules/@sencrop/capacitor-intercom/ios/Plugin/IntercomPlugin.swift:36:22: ambiguous use of 'setDeviceToken'
            Intercom.setDeviceToken(deviceToken) { error in
```